### PR TITLE
Feature/parse dn from cert

### DIFF
--- a/src/main/java/eu/interop/federationgateway/config/EfgsProperties.java
+++ b/src/main/java/eu/interop/federationgateway/config/EfgsProperties.java
@@ -105,7 +105,7 @@ public class EfgsProperties {
       private String thumbprint;
       private String distinguishedName;
       private String fullCert;
-      private Boolean calculateHash = false;
+      private Boolean useFullCertificate = false;
     }
   }
 }

--- a/src/main/java/eu/interop/federationgateway/filter/CertificateAuthentificationFilter.java
+++ b/src/main/java/eu/interop/federationgateway/filter/CertificateAuthentificationFilter.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
@@ -134,11 +135,13 @@ public class CertificateAuthentificationFilter extends OncePerRequestFilter {
       httpServletRequest.getHeader(properties.getCertAuth().getHeaderFields().getDistinguishedName());
     String certificateHash = httpServletRequest.getHeader(properties.getCertAuth().getHeaderFields().getThumbprint());
 
-    if (properties.getCertAuth().getHeaderFields().getCalculateHash()) {
+    if (properties.getCertAuth().getHeaderFields().getUseFullCertificate()) {
       String certificate = httpServletRequest.getHeader(properties.getCertAuth().getHeaderFields().getFullCert());
+      X509Certificate clientCertificate = CertificateUtils.getCertificateFromRawString(certificate);
       certificateHash = CertificateUtils.getCertThumbprint(
-          CertificateUtils.getCertificateFromRawString(certificate)
+        clientCertificate
       );
+      headerDistinguishedName = clientCertificate.getSubjectDN().toString();
     }
 
     String headerCertThumbprint = normalizeCertificateHash(certificateHash);
@@ -149,8 +152,11 @@ public class CertificateAuthentificationFilter extends OncePerRequestFilter {
         httpServletRequest, httpServletResponse, null, new ResponseStatusException(HttpStatus.FORBIDDEN));
       return;
     }
-
-    headerDistinguishedName = URLDecoder.decode(headerDistinguishedName, StandardCharsets.UTF_8);
+    // if we have a full cert present in the header read the DN string directly
+    // as it is not url encoded
+    if (!properties.getCertAuth().getHeaderFields().getUseFullCertificate()) {
+      headerDistinguishedName = URLDecoder.decode(headerDistinguishedName, StandardCharsets.UTF_8);
+    }
 
     EfgsMdc.put("dnString", headerDistinguishedName);
     EfgsMdc.put("thumbprint", headerCertThumbprint);

--- a/src/test/java/eu/interop/federationgateway/filter/CertAuthFilterTestWithFullCert.java
+++ b/src/test/java/eu/interop/federationgateway/filter/CertAuthFilterTestWithFullCert.java
@@ -85,7 +85,7 @@
 
       diagnosisKeyEntityRepository.deleteAll();
       diagnosisKeyBatchRepository.deleteAll();
-      properties.getCertAuth().getHeaderFields().setCalculateHash(true);
+      properties.getCertAuth().getHeaderFields().setUseFullCertificate(true);
 
       mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilter(certFilter).build();
     }
@@ -117,7 +117,6 @@
 
       mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
         .header(properties.getCertAuth().getHeaderFields().getFullCert(), base64DERcertificate)
-        .header(properties.getCertAuth().getHeaderFields().getDistinguishedName(), "O=Test Firma GmbH,O=XXX,C=DE,U=Abteilung XYZ,TR=test")
       ).andExpect(mvcResult -> {
         Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
       });
@@ -130,7 +129,6 @@
 
       mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
         .header(properties.getCertAuth().getHeaderFields().getFullCert(), urlEncodedPem)
-        .header(properties.getCertAuth().getHeaderFields().getDistinguishedName(), "O=Test Firma GmbH,O=XXX,C=DE,U=Abteilung XYZ,TR=test")
       ).andExpect(mvcResult -> {
         Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
       });
@@ -143,7 +141,6 @@
 
       mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
         .header(properties.getCertAuth().getHeaderFields().getFullCert(), urlEncodedPem)
-        .header(properties.getCertAuth().getHeaderFields().getDistinguishedName(), "O=Test Firma GmbH,O=XXX,C=DE,U=Abteilung XYZ,TR=test")
       ).andExpect(mvcResult -> {
         Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
       });
@@ -155,7 +152,6 @@
 
       mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
         .header(properties.getCertAuth().getHeaderFields().getFullCert(), PemEscapedLineEndingsCertificate)
-        .header(properties.getCertAuth().getHeaderFields().getDistinguishedName(), "O=Test Firma GmbH,O=XXX,C=DE,U=Abteilung XYZ,TR=test")
       ).andExpect(mvcResult -> {
         Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
       });
@@ -167,7 +163,6 @@
 
       mockMvc.perform(get("/diagnosiskeys/download/s").accept("application/protobuf; version=1.0")
         .header(properties.getCertAuth().getHeaderFields().getFullCert(), PemEscapedWindowsLineEndingsCertificate)
-        .header(properties.getCertAuth().getHeaderFields().getDistinguishedName(), "O=Test Firma GmbH,O=XXX,C=DE,U=Abteilung XYZ,TR=test")
       ).andExpect(mvcResult -> {
         Assert.assertEquals("DE", mvcResult.getRequest().getAttribute(CertificateAuthentificationFilter.REQUEST_PROP_COUNTRY));
       });


### PR DESCRIPTION
If we provide the full certificate in the header, there is no need to supply the DN as it can simply be read out from the x509Certificate